### PR TITLE
mousedown/up vs click

### DIFF
--- a/index.js
+++ b/index.js
@@ -151,7 +151,7 @@ Menu.prototype.add = function(text, fn){
     , el = o('<li><a href="#">' + text + '</a></li>')
     .addClass('menu-item-' + slug)
     .appendTo(this.el)
-    .mousedown(function(e){
+    .mouseup(function(e){
       e.preventDefault();
       e.stopPropagation();
       self.hide();

--- a/index.js
+++ b/index.js
@@ -32,7 +32,7 @@ function Menu() {
   this.items = {};
   this.el = o('<ul class=menu>').hide().appendTo('body');
   this.el.hover(this.deselect.bind(this));
-  o('html').click(this.hide.bind(this));
+  o('html').mousedown(this.hide.bind(this));
   this.on('show', this.bindKeyboardEvents.bind(this));
   this.on('hide', this.unbindKeyboardEvents.bind(this));
 }
@@ -151,7 +151,7 @@ Menu.prototype.add = function(text, fn){
     , el = o('<li><a href="#">' + text + '</a></li>')
     .addClass('menu-item-' + slug)
     .appendTo(this.el)
-    .click(function(e){
+    .mousedown(function(e){
       e.preventDefault();
       e.stopPropagation();
       self.hide();


### PR DESCRIPTION
This allows the menu to close immediately when mouse clicks outside the menu (feels more responsive and matches typical menu behaviour), plus, allows for dropdown menu to support a single-click gesture to invoke a selection (i.e. mousedown+drag to item+release to select) rather than a two-click approach.

Best way to test the behaviour is using dropdown tests.
