### PR TITLE
Allow menu item to be handled before `hide`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 
 build: index.js components
-	@component build
+	@component build --dev
 
-components:
-	@component install
+components: component.json
+	@component install --dev
 
 clean:
 	rm -fr build components

--- a/Readme.md
+++ b/Readme.md
@@ -57,11 +57,15 @@ oncontextmenu = function(e){
 };
 ```
 
+## License
+
+MIT
+
 ## API
-  
+
 ### Menu()
 
-  Create a new `Menu`:
+Initialize a new `Menu`.
 
 ```js
 var Menu = require('menu');
@@ -69,11 +73,40 @@ var menu = new Menu();
 var menu = Menu();
 ```
 
-### Menu#add([slug], text, [fn])
+Emits:
 
-  Add a new menu item with the given `text`, optional `slug` and callback `fn`.
+- "show" when shown
+- "hide" when hidden
+- "remove" with the item name when an item is removed
+- "select" (item) when an item is selected
+- * menu item events are emitted when clicked
 
-  Using events to handle selection:
+### Menu.prototype()
+
+Inherit from `Emitter.prototype`.
+
+### Menu.move(`direction`:`String`)
+
+Focus on the next menu item in `direction`.
+
+
+### Menu.get(`slug`:`String`)
+> _returns_ MenuItem
+
+Gets a menu item named `slug`.
+
+
+### Menu.add(`text`:`String`, `fn`:`Function`)
+> _returns_ Menu
+
+Add a new menu item with the given `text`, optional `slug` and callback `fn`.
+
+When the item is clicked `fn()` will be invoked
+and the `Menu` is immediately closed. When clicked
+an event of the name `text` is emitted regardless of
+the callback function being present.
+
+Using events to handle selection:
 
 ```js
 menu.add('Hello');
@@ -83,7 +116,7 @@ menu.on('Hello', function(){
 });
 ```
 
-  Using callbacks:
+Using callbacks:
 
 ```js
 menu.add('Hello', function(){
@@ -91,9 +124,9 @@ menu.add('Hello', function(){
 });
 ```
 
-  Using a custom slug, otherwise "hello" is generated
-  from the `text` given, which may conflict with "rich"
-  styling like icons within menu items, or i18n.
+Using a custom slug, otherwise "hello" is generated
+from the `text` given, which may conflict with "rich"
+styling like icons within menu items, or i18n.
 
 ```js
 menu.add('add-item', 'Add Item');
@@ -107,25 +140,39 @@ menu.add('add-item', 'Add Item', function(){
 });
 ```
 
-### Menu#remove(slug)
+### Menu.remove(`slug`:`String`)
+> _returns_ Menu
 
-  Remove an item by the given `slug`:
+Remove an item by the given `slug`:
 
 ```js
 menu.add('Add item');
 menu.remove('Add item');
 ```
 
-  Or with custom slugs:
+Or with custom slugs:
 
 ```js
 menu.add('add-item', 'Add item');
 menu.remove('add-item');
 ```
 
-### Menu#has(slug)
+### Menu.change(`slug`:`String`)
+> _returns_ Menu
 
-  Check if a menu item is present.
+Change menu item with `slug`.
+
+
+### Menu.clear()
+> _returns_ Menu
+
+Clear menu.
+
+
+### Menu.has(`item`:`MenuItem`)
+> _returns_ Boolean
+
+Check if a menu item is present.
 
 ```js
 menu.add('Add item');
@@ -140,18 +187,80 @@ menu.has('Foo');
 // => false
 ```
 
-### Menu#moveTo(x, y)
+### Menu.indexOf(`item`:`MenuItem`)
+> _returns_ Number
 
-  Move the menu to `(x, y)`.
+Find index of menu `item`.
 
-### Menu#show()
 
-  Show the menu.
+### Menu.moveTo(`x`:`Number`, `y`:`Number`)
+> _returns_ Menu
 
-### Menu#hide()
+Move context menu to `(x, y)`.
 
-  Hide the menu.
 
-## License
+### Menu.moveToCenter(`x`:`Number`, `y`:`Number`)
+> _returns_ Menu
 
-  MIT
+Move context menu to `(x, y)`.
+
+
+### Menu.show()
+> _returns_ Menu
+
+Show the menu.
+
+
+### Menu.hide()
+> _returns_ Menu
+
+Hide the menu.
+
+
+### Menu.showItem(`item`:`Element`)
+> _returns_ Menu
+
+Show a menu item.
+
+
+### Menu.hideItem(`item`:`Element`)
+> _returns_ Menu
+
+Hide a menu item.
+
+
+### Menu.unhideAll()
+> _returns_ Menu
+
+Unhide all items.
+
+
+### Menu.toggle()
+> _returns_ Menu
+
+Toggle the menu.
+
+
+### Menu.filter(`fn`:`Function`)
+> _returns_ Menu
+
+Filter menu using `fn`.
+
+
+### Menu.isOpen()
+> _returns_ Boolean
+
+Check if menu is visible.
+
+
+### Menu.isSelecting()
+> _returns_ Boolean
+
+Check if user is selecting.
+
+
+### MenuItem(`item`:`Object`)
+
+MenuItem class.
+
+

--- a/component.json
+++ b/component.json
@@ -1,7 +1,7 @@
 {
   "name": "menu",
   "description": "Menu component",
-  "version": "0.1.1",
+  "version": "0.2.0",
   "keywords": [
     "menu",
     "ui"

--- a/component.json
+++ b/component.json
@@ -8,7 +8,11 @@
   ],
   "dependencies": {
     "component/emitter": "*",
-    "component/jquery": "*"
+    "component/jquery": "*",
+    "pazguille/viewport": "*"
+  },
+  "development": {
+    "stagas/watch-js": "*"
   },
   "styles": [
     "menu.css"

--- a/component.json
+++ b/component.json
@@ -9,7 +9,7 @@
   "dependencies": {
     "component/emitter": "*",
     "component/jquery": "*",
-    "pazguille/viewport": "*"
+    "stagas/viewport": "*"
   },
   "development": {
     "stagas/watch-js": "*"

--- a/index.js
+++ b/index.js
@@ -16,13 +16,19 @@ module.exports = Menu;
 /**
  * Initialize a new `Menu`.
  *
+ * ```js
+ * var Menu = require('menu');
+ * var menu = new Menu();
+ * var menu = Menu();
+ * ```
+ *
  * Emits:
  *
- *   - "show" when shown
- *   - "hide" when hidden
- *   - "remove" with the item name when an item is removed
- *   - "select" (item) when an item is selected
- *   - * menu item events are emitted when clicked
+ * - "show" when shown
+ * - "hide" when hidden
+ * - "remove" with the item name when an item is removed
+ * - "select" (item) when an item is selected
+ * - * menu item events are emitted when clicked
  *
  * @api public
  */
@@ -67,7 +73,8 @@ Menu.prototype.bindEvents = function(){
   this.once('hide', function () {
     if (this.selected) {
       this.emit('select', this.selected)
-      this.emit(this.selected.slug, this.selected.text, this.selected.meta)
+      this.emit(this.selected.slug, this.selected)
+      this.emit(this.selected.text, this.selected)
       this.selected.fn && this.selected.fn()
     }
   })
@@ -238,7 +245,7 @@ Menu.prototype.move = function(direction){
  * Gets a menu item named `slug`.
  *
  * @param {String} slug
- * @return {Element}
+ * @return {MenuItem}
  * @api public
  */
 
@@ -251,12 +258,46 @@ Menu.prototype.get = function(slug){
 };
 
 /**
- * Add menu item with the given `text` and optional callback `fn`.
+ * Add a new menu item with the given `text`, optional `slug` and callback `fn`.
  *
  * When the item is clicked `fn()` will be invoked
  * and the `Menu` is immediately closed. When clicked
  * an event of the name `text` is emitted regardless of
  * the callback function being present.
+ *
+ * Using events to handle selection:
+ *
+ * ```js
+ * menu.add('Hello');
+ *
+ * menu.on('Hello', function(){
+ *   console.log('clicked hello');
+ * });
+ * ```
+ *
+ * Using callbacks:
+ *
+ * ```js
+ * menu.add('Hello', function(){
+ *   console.log('clicked hello');
+ * });
+ * ```
+ *
+ * Using a custom slug, otherwise "hello" is generated
+ * from the `text` given, which may conflict with "rich"
+ * styling like icons within menu items, or i18n.
+ *
+ * ```js
+ * menu.add('add-item', 'Add Item');
+ *
+ * menu.on('add-item', function(){
+ *   console.log('clicked "Add Item"');
+ * });
+ *
+ * menu.add('add-item', 'Add Item', function(){
+ *   console.log('clicked "Add Item"');
+ * });
+ * ```
  *
  * @param {String} text
  * @param {Function} fn
@@ -298,10 +339,6 @@ Menu.prototype.add = function(text, fn){
     self.select(item);
   });
 
-  if (this.has(slug)) {
-    this.hideItem(el);
-  }
-
   var item = new MenuItem({
     el: el
   , text: text
@@ -310,13 +347,29 @@ Menu.prototype.add = function(text, fn){
   , fn: fn
   });
 
+  if (this.has(slug)) {
+    this.hideItem(item);
+  }
+
   this.items.push(item);
 
   return this;
 };
 
 /**
- * Remove menu item by `slug`.
+ * Remove an item by the given `slug`:
+ *
+ * ```js
+ * menu.add('Add item');
+ * menu.remove('Add item');
+ * ```
+ *
+ * Or with custom slugs:
+ *
+ * ```js
+ * menu.add('add-item', 'Add item');
+ * menu.remove('add-item');
+ * ```
  *
  * @param {String} slug
  * @return {Menu}
@@ -370,7 +423,20 @@ Menu.prototype.clear = function(){
 };
 
 /**
- * Check if this menu has `item`.
+ * Check if a menu item is present.
+ *
+ * ```js
+ * menu.add('Add item');
+ *
+ * menu.has('Add item');
+ * // => true
+ *
+ * menu.has('add-item');
+ * // => true
+ *
+ * menu.has('Foo');
+ * // => false
+ * ```
  *
  * @param {MenuItem} item
  * @return {Boolean}
@@ -479,7 +545,7 @@ Menu.prototype.hide = function(){
 /**
  * Show a menu item.
  *
- * @param {Element} item
+ * @param {MenuItem} item
  * @return {Menu}
  * @api public
  */
@@ -493,7 +559,7 @@ Menu.prototype.showItem = function(item){
 /**
  * Hide a menu item.
  *
- * @param {Element} item
+ * @param {MenuItem} item
  * @return {Menu}
  * @api public
  */

--- a/index.js
+++ b/index.js
@@ -321,6 +321,10 @@ Menu.prototype.add = function(text, fn){
     slug = text;
     text = fn;
     fn = arguments[2];
+    if ('function' != typeof fn) {
+      meta = fn;
+      fn = arguments[3];
+    }
   } else {
     slug = createSlug(text);
   }

--- a/index.js
+++ b/index.js
@@ -155,11 +155,17 @@ Menu.prototype.emitSelected = function(){
 
 Menu.prototype.onkeydown = function(e){
   switch (e.keyCode) {
-    case 13: // enter
     case 39: // right
     case 9: // tab
       this.emitSelected();
       this.hide();
+    break;
+
+    case 13: // enter
+      e.preventDefault();
+      this.emitSelected();
+      this.hide();
+      return false;
     break;
 
     case 27: // tab

--- a/index.js
+++ b/index.js
@@ -70,14 +70,6 @@ Menu.prototype.deselect = function(ev){
 Menu.prototype.bindEvents = function(){
   this.bindKeyboardEvents();
   this.bindMouseEvents();
-  this.once('hide', function () {
-    if (this.selected) {
-      this.emit('select', this.selected)
-      this.emit(this.selected.slug, this.selected)
-      this.emit(this.selected.text, this.selected)
-      this.selected.fn && this.selected.fn()
-    }
-  })
 };
 
 /**
@@ -141,6 +133,21 @@ Menu.prototype.unbindKeyboardEvents = function(){
 };
 
 /**
+ * Emit selected if any.
+ *
+ * @api private
+ */
+
+Menu.prototype.emitSelected = function(){
+  if (this.selected) {
+    this.emit('select', this.selected);
+    this.emit(this.selected.slug, this.selected);
+    this.emit(this.selected.text, this.selected);
+    this.selected.fn && this.selected.fn();
+  }
+};
+
+/**
  * Handle keydown events.
  *
  * @api private
@@ -148,31 +155,26 @@ Menu.prototype.unbindKeyboardEvents = function(){
 
 Menu.prototype.onkeydown = function(e){
   switch (e.keyCode) {
-    // enter
-    case 13:
+    case 13: // enter
+    case 39: // right
+    case 9: // tab
+      this.emitSelected();
       this.hide();
     break;
 
-    // esc
-    case 27:
+    case 27: // tab
+    case 37: // left
       this.deselect();
       this.hide();
     break;
 
-    // tab
-    case 9:
-      this.hide();
-    break;
-
-    // up
-    case 38:
+    case 38: // up
       e.preventDefault();
       this.move('prev');
       this._isSelecting = true;
     break;
 
-    // down
-    case 40:
+    case 40: // down
       e.preventDefault();
       this.move('next');
       this._isSelecting = true;
@@ -337,6 +339,7 @@ Menu.prototype.add = function(text, fn){
   .on('mouseup', function(e){
     e.preventDefault();
     self.select(item);
+    self.emitSelected();
   });
 
   var item = new MenuItem({

--- a/index.js
+++ b/index.js
@@ -154,10 +154,10 @@ Menu.prototype.add = function(text, fn){
     .click(function(e){
       e.preventDefault();
       e.stopPropagation();
-      self.hide();
       self.emit('select', slug);
       self.emit(slug);
       fn && fn();
+      self.hide();
     });
 
   this.items[slug] = el;

--- a/index.js
+++ b/index.js
@@ -482,16 +482,9 @@ Menu.prototype.indexOf = function(item){
  */
 
 Menu.prototype.moveTo = function(x, y){
-  var height = o(this.el).outerHeight();
   var width = o(this.el).outerWidth();
 
-  if (y+height > viewport.bottom) {
-    y = viewport.bottom-height;
-  }
-
-  if (y < viewport.top) {
-    y = viewport.top;
-  }
+  viewport.refresh();
 
   if (x+width > viewport.right) {
     x = viewport.right-width;
@@ -502,8 +495,23 @@ Menu.prototype.moveTo = function(x, y){
   }
 
   this.el.css({
-    top: y,
     left: x
+  });
+
+  viewport.refresh();
+
+  var height = o(this.el).outerHeight();
+
+  if (y+height > viewport.bottom) {
+    y = viewport.bottom-height;
+  }
+
+  if (y < viewport.top) {
+    y = viewport.top;
+  }
+
+  this.el.css({
+    top: y
   });
 
   return this;

--- a/index.js
+++ b/index.js
@@ -523,9 +523,14 @@ Menu.prototype.moveToCenter = function(x, y){
 
 Menu.prototype.show = function(){
   if (this.isOpen()) return this;
+
+  if (!this.hasVisibleItems()) return this;
+
   this.el.show();
   this._isOpen = true;
+
   this.emit('show');
+
   return this;
 };
 
@@ -538,10 +543,14 @@ Menu.prototype.show = function(){
 
 Menu.prototype.hide = function(){
   if (!this.isOpen()) return this;
+
   this.emit('hide');
+
   this.el.hide();
   this._isOpen = false;
+
   this._isSelecting = false
+
   return this;
 };
 
@@ -611,6 +620,7 @@ Menu.prototype.toggle = function(){
 
 Menu.prototype.filter = function(fn){
   var self = this;
+
   this.items.forEach(function (item) {
     if (fn(item)) {
       self.showItem(item);
@@ -619,7 +629,23 @@ Menu.prototype.filter = function(fn){
       self.hideItem(item);
     }
   });
+
+  if (!this.hasVisibleItems()) this.hide();
+
   return this;
+};
+
+/**
+ * Check if there are visible items.
+ *
+ * @return {Boolean}
+ * @api private
+ */
+
+Menu.prototype.hasVisibleItems = function(){
+  return this.items.filter(function (item) {
+    return !item.hidden;
+  }).length!=0
 };
 
 /**

--- a/menu.css
+++ b/menu.css
@@ -19,6 +19,7 @@
   text-decoration: none;
   border-top: 1px solid #eee;
   color: #2e2e2e;
+  min-width: 120px;
   outline: none;
 }
 

--- a/menu.css
+++ b/menu.css
@@ -8,7 +8,9 @@
   padding: 0;
   min-width: 120px;
   background: white;
-  border: 1px solid rgba(0,0,0,0.2);
+  border: 1px solid rgba(0,0,0,.3);
+  font-family: sans-serif;
+  font-size: 14px;
   -moz-box-sizing: border-box;
   -webkit-box-sizing: border-box;
   -o-box-sizing: border-box;
@@ -21,7 +23,7 @@
 
 .menu li a {
   display: block;
-  padding: 5px 30px 5px 12px;
+  padding: 7.5px 15px 7.5px;
   text-decoration: none;
   border-top: 1px solid #eee;
   color: #2e2e2e;
@@ -34,5 +36,6 @@
 
 .menu li a:hover,
 .menu li.selected a {
-  background: #f1faff;
+  color: #fff;
+  background: #46a;
 }

--- a/menu.css
+++ b/menu.css
@@ -1,3 +1,4 @@
+
 .menu {
   position: absolute;
   top: 0;
@@ -5,8 +6,13 @@
   z-index: 100;
   margin: 0;
   padding: 0;
+  min-width: 120px;
   background: white;
   border: 1px solid rgba(0,0,0,0.2);
+  -moz-box-sizing: border-box;
+  -webkit-box-sizing: border-box;
+  -o-box-sizing: border-box;
+  box-sizing: border-box;
 }
 
 .menu li {
@@ -19,7 +25,6 @@
   text-decoration: none;
   border-top: 1px solid #eee;
   color: #2e2e2e;
-  min-width: 120px;
   outline: none;
 }
 

--- a/test/index.html
+++ b/test/index.html
@@ -10,24 +10,24 @@
     html {
       width: 100%;
       height: 100%;
+      font-family: sans-serif;
     }
 
     body {
       margin: 0;
-      padding: 0;
+      padding: 50px;
     }
 
+    .bigbox {
+      width: 2000px;
+      height: 2000px;
+    }
     </style>
   </head>
   <body>
     <title>Menu</title>
-    <p>some<p>really<p>long<p>content
-    <p>some<p>really<p>long<p>content
-    <p>some<p>really<p>long<p>content
-    <p>some<p>really<p>long<p>content
-    <p>some<p>really<p>long<p>content
-    <p>some<p>really<p>long<p>content
-    <p>some<p>really<p>long<p>content
+    Try right clicking anywhere on this page
+    <div class="bigbox"></div>
     <script src="../build/build.js"></script>
     <script>
       require('stagas-watch-js');

--- a/test/index.html
+++ b/test/index.html
@@ -3,23 +3,54 @@
   <head>
     <title>Menu</title>
     <meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+    <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="stylesheet" href="../build/build.css" />
+    <style>
+
+    html {
+      width: 100%;
+      height: 100%;
+    }
+
+    body {
+      margin: 0;
+      padding: 0;
+    }
+
+    </style>
   </head>
   <body>
     <title>Menu</title>
+    <p>some<p>really<p>long<p>content
+    <p>some<p>really<p>long<p>content
+    <p>some<p>really<p>long<p>content
+    <p>some<p>really<p>long<p>content
+    <p>some<p>really<p>long<p>content
+    <p>some<p>really<p>long<p>content
+    <p>some<p>really<p>long<p>content
     <script src="../build/build.js"></script>
     <script>
+      require('stagas-watch-js');
       var menu = require('menu');
-  
+
       menu = menu();
-  
+
       menu
-      .add('add-item', 'Add <em>item</em>')
+      .add('add-item', 'Add <em>item</em>', function(){ menu.add('Item'); })
       .add('Edit item', function(){ console.log('edit'); })
       .add('Remove item', function(){ console.log('remove'); })
       .add('Remove "Add item"', function(){
         menu.remove('add-item');
         menu.remove('Remove "Add item"');
+      })
+      .add('Filter', function filterItem (){
+        menu.filter(function(item){
+          return item.slug.substr(0,1) !== 'r'
+        });
+        menu.change('Filter', 'Show all', function(){
+          menu.unhideAll();
+          menu.change('Show all', 'Filter', filterItem);
+        });
       });
 
       menu.on('select', function(item){
@@ -32,7 +63,7 @@
 
       oncontextmenu = function(e){
         e.preventDefault();
-        menu.moveTo(e.pageX, e.pageY);
+        menu.moveToCenter(e.pageX, e.pageY);
         menu.show();
       };
     </script>


### PR DESCRIPTION
I do some cleanup in the `hide` event, but want to allow the item callback to process some the stuff that `hide` cleanups. This fixes it.
